### PR TITLE
Fix image URL validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 dist
 .DS_Store
+tsconfig.tsbuildinfo

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -77,14 +77,14 @@ const FileUpload: React.FC<FileUploadProps> = ({ onQuestionsLoad }) => {
 
   const validateImageUrl = async (url: string): Promise<boolean> => {
     if (!url || url.trim() === '' || isNoneValue(url)) return true;
-    
+
     if (!isValidImageUrl(url)) {
       return false;
     }
 
     try {
-      await tryImageHeadRequest(url);
-      return true;
+      const result = await tryImageHeadRequest(url);
+      return result;
     } catch {
       return isValidImageUrl(url);
     }


### PR DESCRIPTION
## Summary
- correctly check result from HEAD request when validating image URLs
- ignore TypeScript build info

## Testing
- `npm run build` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685eb1f8eb7c832f996d0cbdeaa929cc